### PR TITLE
Change probability system from percentage-based to weight-based

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -11,9 +11,7 @@ export default function App()
         </div>
         <div>
           <h2>Da Rules:</h2>
-          <p>1. The probabilities should add up to 1.</p>
-          <p>2. A probability should be in the range of 0-1.</p>
-          <p>3. The probability number should be up to 2 numbers after the decimal point (for example: 0.45).</p>
+          <p>#yolo</p>
         </div>
       </div>
     );

--- a/src/components/WheelForm.js
+++ b/src/components/WheelForm.js
@@ -27,7 +27,6 @@ const chooseRandom = (choices) => {
 
   for (let i = 0; i < choices.length; i++) {
     cumulative_prob += parseFloat(choices[i].weight) / weight_total
-    console.log(cumulative_prob+", " + rand_num)
     if (rand_num < cumulative_prob) {
       return i;
     }


### PR DESCRIPTION
Pretty straight forward. The idea is to convert the probability as a representation of weights over decimal percentages. This solves both end-user frustrations in dealing with decimal percentages & it being matched by other foes, as well as increase accuracy for floating numbers (most dominantly `.3`).

Additionally expanded upon DRY implementations, adding various jsdocs and object definitions;
- Removed `editable` property, replaced with index match (since the only editable component is always the last one)
- Moved Random function outside the `WheelForm` component
- `updateChoice` function now accepts a Choice consumer instead of a fixed key value
- Added `validateChoice`, self explanatory
- That's it I think

Have a nice one Mr. Ha'arel